### PR TITLE
Static artifact direct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ deploy:
   provider: releases
   skip_cleanup: true
   api_key: $GITHUB_TOKEN
-  repo: gitter-bioinf/sequenceTools
+  repo: sequencetoolsconda/sequenceTools
   file: "sequencetools_static.x86_64-linux.tar.gz"
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: required
+
+language: c
+
+services:
+  - docker
+
+jobs:
+  include:
+  - name: "Static artifact"
+    if: tag IS present
+    before_script:
+      - docker build --tag linux -f Dockerfile.static-linux .
+    script:
+      - docker create --name linuxcontainer linux
+      - docker cp linuxcontainer:/sequencetools_dist sequenceTools_x86_64-linux
+      - cp LICENSE sequenceTools_x86_64-linux
+      - tar -cvzf sequencetools_static.x86_64-linux.tar.gz sequenceTools_x86_64-linux
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key: $GITHUB_TOKEN
+  repo: gitter-bioinf/sequenceTools
+  file: "sequencetools_static.x86_64-linux.tar.gz"
+  on:
+    tags: true
+

--- a/Dockerfile.static-linux
+++ b/Dockerfile.static-linux
@@ -1,0 +1,9 @@
+FROM alpine:edge
+
+RUN apk update
+RUN apk add --no-cache musl musl-dev musl-utils musl-dbg ghc ghc-dev ghc-doc cabal zlib-dev zlib zlib-static tar gzip wget
+RUN mkdir /sequencetools_dist
+ADD . source
+WORKDIR source
+RUN cabal new-update && cabal new-build --ghc-options="-threaded -optl-static -optl-pthread -fPIC"
+RUN find dist-newstyle -type f | grep "\/build\/" | grep "genoStats$\|pileupCaller$\|vcf2eigenstrat$" | xargs -I "{}" cp {} /sequencetools_dist/


### PR DESCRIPTION
This will use Travis CI to build sequencetools_static.x86_64-linux.tar.gz and publish it to:

https://github.com/sequencetoolsconda/sequenceTools/releases

The job to build this artifact is only triggered when a tag is pushed. From here it is down to:

https://github.com/sequencetoolsconda/bioconda-recipes/tree/master/recipes/sequencetools

which installs sequencetools for conda users.